### PR TITLE
Fix: Don't execute <script> with custom type (fixes #8)

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "license": "MIT",
   "main": "./lib/index.js",
   "scripts": {
-    "test": "./node_modules/karma/bin/karma start --single-run",
+    "test": "node ./node_modules/karma/bin/karma start --single-run",
     "prepublish": "./node_modules/.bin/coffee -o lib -c src/*.coffee"
   },
   "repository": {

--- a/spec/fixture_spec.coffee
+++ b/spec/fixture_spec.coffee
@@ -2,10 +2,14 @@ json_data = {
   test1: 'check'
   test2: 'ok'
 }
+
 json_template = JSON.stringify(json_data)
 html_template1 = '<h1 id="tmpl">test</h1>'
 html_template2 = '<h2 id="tmpl">test</h2><p>multiple</p>'
 html_template3 = '<script>window.test_a_test = true</script>'
+html_template4 = '<script type="text/javascript">window.test_b_test = true</script>'
+html_template5 = '<script type="application/javascript">window.test_c_test = true</script>'
+html_template6 = '<script type="text/x-custom">window.test_d_test = true</script>'
 fixture_base = 'spec/fixtures'
 
 load_template_as_karma_html2js = (name, string, base = fixture_base)->
@@ -83,6 +87,9 @@ describe 'Fixture', ->
         load_template_as_karma_html2js 'html1', html_template1
         load_template_as_karma_html2js 'html2', html_template2
         load_template_as_karma_html2js 'html3', html_template3
+        load_template_as_karma_html2js 'html4', html_template4
+        load_template_as_karma_html2js 'html5', html_template5
+        load_template_as_karma_html2js 'html6', html_template6
         load_template_as_karma_html2js 'json.json', json_template
 
       afterEach ->
@@ -137,7 +144,7 @@ describe 'Fixture', ->
         @instance.load('/test_base/html4')
         expect(@fixture_cont.innerHTML).to.equal('<p>test</p>')
 
-      context 'when template contains <script> tags', ->
+      context 'when template contains <script> tags without type', ->
         beforeEach ->
           @instance.load 'html3'
 
@@ -146,6 +153,36 @@ describe 'Fixture', ->
 
         it 'executes the javascript', ->
           expect(window.test_a_test).to.equal true
+
+      context 'when template contains <script> tags with text/javascript type', ->
+        beforeEach ->
+          @instance.load 'html4'
+
+        it 'places the script tag intact', ->
+          expect(@fixture_cont.innerHTML).to.equal html_template4
+
+        it 'executes the javascript', ->
+          expect(window.test_b_test).to.equal true
+
+      context 'when template contains <script> tags with application/javascript type', ->
+        beforeEach ->
+          @instance.load 'html5'
+
+        it 'places the script tag intact', ->
+          expect(@fixture_cont.innerHTML).to.equal html_template5
+
+        it 'executes the javascript', ->
+          expect(window.test_c_test).to.equal true
+
+      context 'when template contains <script> tags with text/x-custom type', ->
+        beforeEach ->
+          @instance.load 'html6'
+
+        it 'places the script tag intact', ->
+          expect(@fixture_cont.innerHTML).to.equal html_template6
+
+        it 'does not execute the javascript', ->
+          expect(window.test_d_test).to.equal undefined
 
       context 'when multiple templates are requested', ->
         beforeEach ->

--- a/src/fixture.coffee
+++ b/src/fixture.coffee
@@ -2,6 +2,24 @@ class Fixture
 
   constructor: (@base = 'spec/fixtures', @id = 'fixture_container') ->
     @json = []
+    @scriptTypes = {
+      'application/ecmascript': 1,
+      'application/javascript': 1,
+      'application/x-ecmascript': 1,
+      'application/x-javascript': 1,
+      'text/ecmascript': 1,
+      'text/javascript': 1,
+      'text/javascript1.0': 1,
+      'text/javascript1.1': 1,
+      'text/javascript1.2': 1,
+      'text/javascript1.3': 1,
+      'text/javascript1.4': 1,
+      'text/javascript1.5': 1,
+      'text/jscript': 1,
+      'text/livescript': 1,
+      'text/x-ecmascript': 1,
+      'text/x-javascript': 1
+    }
 
     @el = window[@id] or (=>
       container = document.createElement 'div'
@@ -70,7 +88,7 @@ class Fixture
       else
         @el.appendChild(i)
         results.push i
-        eval i.innerText if i.nodeName is 'SCRIPT'
+        eval (i.innerText || i.textContent) if i.nodeName is 'SCRIPT' and (!i.type or @scriptTypes[i.type])
     return results
 
   _throwNoFixture: (fixture_path)->


### PR DESCRIPTION
I've never written CoffeeScript before, so I'm hoping this is useful. :)

Notes:
1. I had to make one change to package.json in order for `npm test` to work on Windows. This change should be compatible with other systems as well.
2. There are a number of content-types that can be interpreted as JavaScript, I included them all in an array.
3. Since Firefox doesn't support `innerText`, this was silently failing. I added `textContent` so it will work in Firefox.
